### PR TITLE
Fix compilation issue when BAREMETAL flag is set

### DIFF
--- a/source/cs_topology.c
+++ b/source/cs_topology.c
@@ -738,7 +738,7 @@ static void _cs_link_affinity(struct cs_device *dbg,
 }
 
 /* Used in asserts only */
-#ifdef DEBUG
+#if defined(DEBUG) || defined(BAREMETAL)
 static int cs_device_has_atb_out(struct cs_device *d)
 {
     return (d->devclass & (CS_DEVCLASS_SOURCE | CS_DEVCLASS_LINK)) != 0;


### PR DESCRIPTION
When compiling for BAREMETAL functions the functions under define is in use also (it's in use not only for DEBUG as stated in the comment)