### PR TITLE
GitHub Action to find typos and lint Python code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://docs.astral.sh/ruff/
+name: ci
+on:
+  push:
+    # branches: [main, master]
+  pull_request:
+    # branches: [main, master]
+jobs:
+  codespell:
+    runs-on: ubuntu-24.04-arm
+    steps:
+    - uses: actions/checkout@v4
+    - uses: codespell-project/actions-codespell@v2
+      with:
+        ignore_words_list: earch,ect,flushin,vas
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: astral-sh/ruff-action@v3
+      with:
+        args: check --ignore=ALL


### PR DESCRIPTION
# Test results: https://github.com/cclauss/CSAL/actions
* [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`
* https://github.com/codespell-project/codespell
* https://docs.astral.sh/ruff
* https://docs.astral.sh/ruff/linter